### PR TITLE
Fix ITGlue contact creation - use correct label-name field

### DIFF
--- a/Modules/CippExtensions/Public/ITGlue/Invoke-ITGlueExtensionSync.ps1
+++ b/Modules/CippExtensions/Public/ITGlue/Invoke-ITGlueExtensionSync.ps1
@@ -206,7 +206,7 @@ $(if ($Mailbox) { "<p><strong>Mailbox Size:</strong> $($Mailbox.TotalItemSize)</
                             'first-name'      = if ($User.givenName) { $User.givenName } else { $User.displayName }
                             'last-name'       = $User.surname
                             title             = $User.jobTitle
-                            'contact-emails'  = @(@{ value = $User.userPrincipalName; primary = $true; label = 'Work' })
+                            'contact-emails'  = @(@{ value = $User.userPrincipalName; primary = $true; 'label-name' = 'Work' })
                         }
 
                         if ($ExistingContact) {


### PR DESCRIPTION
## Summary
- Fix 422 error when creating ITGlue contacts
- The ITGlue API requires `label-name` instead of `label` in the `contact-emails` array

## Issue
```
Contact [james@tarrantech.co.uk]: ITGlue API error (422) on POST /contacts : can't be blank
```

## Fix
Changed `label = 'Work'` to `'label-name' = 'Work'` in the contact-emails structure.

## Test plan
- [ ] Verify contacts sync without 422 errors
- [ ] Confirm email label displays correctly in ITGlue

🤖 Generated with [Claude Code](https://claude.com/claude-code)