### PR TITLE
Fix ITGlue quick-notes duplicating CIPP section on every sync

### DIFF
--- a/Modules/CippExtensions/Public/ITGlue/Invoke-ITGlueExtensionSync.ps1
+++ b/Modules/CippExtensions/Public/ITGlue/Invoke-ITGlueExtensionSync.ps1
@@ -359,7 +359,12 @@ $(if ($Mailbox) { "<p><strong>Mailbox Size:</strong> $($Mailbox.TotalItemSize)</
         # ─────────────────────────────────────────────────────────────────────
         if ($ITGlueConfig.ImportDomains -eq $true -and $Domains) {
             try {
-                $VerifiedDomains = ($Domains | Where-Object { $_.isVerified -eq $true }).id -join ', '
+                $VerifiedDomainList = ($Domains | Where-Object { $_.isVerified -eq $true }).id
+                $VerifiedDomains = if ($VerifiedDomainList) {
+                    '<ul>' + (($VerifiedDomainList | ForEach-Object { "<li>$_</li>" }) -join '') + '</ul>'
+                } else {
+                    '<p>None</p>'
+                }
 
                 # Build license table rows
                 $LicenseRows = if ($Licenses) {
@@ -389,7 +394,8 @@ $CippMarkerStart
 <strong>Tenant ID:</strong> <code>$($Tenant.customerId)</code><br/>
 <strong>Default Domain:</strong> $($Tenant.defaultDomainName)</p>
 
-<p><strong>Verified Domains:</strong> $VerifiedDomains</p>
+<p><strong>Verified Domains:</strong></p>
+$VerifiedDomains
 
 <table>
 <tr><td><strong>Licensed Users</strong></td><td>$($CompanyResult.Users)</td></tr>


### PR DESCRIPTION
## Summary
- **Bug:** CIPP-managed section in ITGlue quick-notes was appended on every sync instead of replacing the previous version, causing duplicated content
- **Root cause:** HTML comment markers (`<!-- CIPP-MANAGED-START -->`) are stripped by ITGlue's HTML sanitizer, so the replacement regex never matched
- **Fix:** Replaced comment markers with a `<div class="cipp-managed">` wrapper that survives sanitization, with fallback matching for legacy markers and content-based detection to clean up existing duplicates
- Display verified domains as a bullet list instead of a comma-separated string

## Test plan
- [ ] Sync an org with existing duplicated CIPP sections — verify duplicates are replaced with a single section
- [ ] Re-sync the same org — verify the section is replaced in-place, not appended
- [ ] Verify manually-added content above the CIPP section is preserved
- [ ] Sync an org with no existing quick-notes — verify clean creation
- [ ] Confirm verified domains render as a bulleted list