### PR TITLE
Fix ITGlue quick-notes duplicating and format domains as list

### DIFF
--- a/Modules/CippExtensions/Public/ITGlue/Invoke-ITGlueExtensionSync.ps1
+++ b/Modules/CippExtensions/Public/ITGlue/Invoke-ITGlueExtensionSync.ps1
@@ -417,27 +417,14 @@ $CippMarkerEnd
                 $ExistingOrg = Invoke-ITGlueRequest -Method GET -Endpoint "/organizations/$OrgId" -Headers $Conn.Headers -BaseUrl $Conn.BaseUrl -FirstPageOnly
                 $ExistingNotes = $ExistingOrg.'quick-notes'
 
-                if ($ExistingNotes) {
-                    # Try matching our <div class="cipp-managed"> wrapper first
-                    if ($ExistingNotes -match '<div class="cipp-managed">') {
-                        $QuickNotes = $ExistingNotes -replace '(?s)<div class="cipp-managed">.*?</div>', $CippSection
-                    }
-                    # Legacy: match old HTML comment markers (in case ITGlue kept them)
-                    elseif ($ExistingNotes -match '<!-- CIPP-MANAGED-START -->') {
-                        $QuickNotes = $ExistingNotes -replace '(?s)<!-- CIPP-MANAGED-START -->.*?<!-- CIPP-MANAGED-END -->', $CippSection
-                    }
-                    # Fallback: detect orphaned CIPP content by matching on the heading
-                    # and the "(CIPP Managed)" timestamp that we always write
-                    elseif ($ExistingNotes -match '<h3>Microsoft 365 Overview</h3>' -and $ExistingNotes -match '\(CIPP Managed\)') {
-                        $QuickNotes = $ExistingNotes -replace '(?s)(<hr\s*/?>)?\s*<h3>Microsoft 365 Overview</h3>.*?\(CIPP Managed\)</em></p>', $CippSection
-                    }
+                if ($ExistingNotes -and $ExistingNotes -match '\(CIPP Managed\)') {
+                    # Content-based match: use GREEDY .* to capture everything from
+                    # the first M365 Overview heading to the LAST (CIPP Managed) stamp,
+                    # removing all duplicate CIPP sections in one sweep.
+                    $QuickNotes = $ExistingNotes -replace '(?s)(<hr\s*/?>)?\s*<h3>Microsoft 365 Overview</h3>.*(CIPP Managed)</em></p>', $CippSection
+                } elseif ($ExistingNotes -and $ExistingNotes.Trim()) {
                     # No previous CIPP section found - append below existing user content
-                    elseif ($ExistingNotes.Trim()) {
-                        $QuickNotes = $ExistingNotes.TrimEnd() + "`n`n" + $CippSection
-                    }
-                    else {
-                        $QuickNotes = $CippSection -replace '<hr/>\s*', ''
-                    }
+                    $QuickNotes = $ExistingNotes.TrimEnd() + "`n`n" + $CippSection
                 } else {
                     # No existing content, just use CIPP section (without leading hr)
                     $QuickNotes = $CippSection -replace '<hr/>\s*', ''


### PR DESCRIPTION
## Summary
- **Bug:** CIPP-managed section in ITGlue quick-notes was appended on every sync, causing duplicated content
- **Root cause:** ITGlue's HTML sanitizer strips both HTML comments and class attributes, so all marker-based approaches fail. The previous non-greedy regex also replaced each duplicate independently, creating N new copies
- **Fix:** Use greedy content-based regex matching from the first `<h3>Microsoft 365 Overview</h3>` to the last `(CIPP Managed)` timestamp, capturing all duplicates in a single replacement
- Display verified domains as a bulleted list instead of comma-separated string

## Test plan
- [ ] Sync an org with existing duplicated CIPP sections — verify all duplicates are replaced with a single section
- [ ] Re-sync the same org — verify the section is replaced in-place, not appended
- [ ] Verify manually-added content above the CIPP section is preserved
- [ ] Sync an org with no existing quick-notes — verify clean creation
- [ ] Confirm verified domains render as a bulleted list