### PR TITLE
Mailbox Forwarding Report improvements

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListMailboxForwarding.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListMailboxForwarding.ps1
@@ -58,9 +58,8 @@ function Invoke-ListMailboxForwarding {
                 'Internal'
             }
 
-            $ForwardTo = if ($HasExternalForwarding -and $HasInternalForwarding) {
-                "$($Mailbox.ForwardingSmtpAddress -replace 'smtp:', ''), $($Mailbox.ForwardingAddress)"
-            } elseif ($HasExternalForwarding) {
+            # External takes precedence when both are configured
+            $ForwardTo = if ($HasExternalForwarding) {
                 $Mailbox.ForwardingSmtpAddress -replace 'smtp:', ''
             } else {
                 $Mailbox.ForwardingAddress

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListMailboxForwarding.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListMailboxForwarding.ps1
@@ -58,7 +58,9 @@ function Invoke-ListMailboxForwarding {
                 'Internal'
             }
 
-            $ForwardTo = if ($HasExternalForwarding) {
+            $ForwardTo = if ($HasExternalForwarding -and $HasInternalForwarding) {
+                "$($Mailbox.ForwardingSmtpAddress -replace 'smtp:', ''), $($Mailbox.ForwardingAddress)"
+            } elseif ($HasExternalForwarding) {
                 $Mailbox.ForwardingSmtpAddress -replace 'smtp:', ''
             } else {
                 $Mailbox.ForwardingAddress

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListMailboxForwarding.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListMailboxForwarding.ps1
@@ -11,20 +11,12 @@ function Invoke-ListMailboxForwarding {
     $APIName = $Request.Params.CIPPEndpoint
     $TenantFilter = $Request.Query.tenantFilter
     $UseReportDB = $Request.Query.UseReportDB
-    $ForwardingOnly = $Request.Query.ForwardingOnly
 
     try {
         # If UseReportDB is specified, retrieve from report database
         if ($UseReportDB -eq 'true') {
-            $ReportParams = @{
-                TenantFilter = $TenantFilter
-            }
-            if ($ForwardingOnly -eq 'true') {
-                $ReportParams.ForwardingOnly = $true
-            }
-
             try {
-                $GraphRequest = Get-CIPPMailboxForwardingReport @ReportParams
+                $GraphRequest = Get-CIPPMailboxForwardingReport -TenantFilter $TenantFilter
                 $StatusCode = [HttpStatusCode]::OK
             } catch {
                 $StatusCode = [HttpStatusCode]::InternalServerError
@@ -53,22 +45,23 @@ function Invoke-ListMailboxForwarding {
             $HasInternalForwarding = -not [string]::IsNullOrWhiteSpace($Mailbox.ForwardingAddress)
             $HasAnyForwarding = $HasExternalForwarding -or $HasInternalForwarding
 
+            # Only include mailboxes with forwarding configured
+            if (-not $HasAnyForwarding) {
+                continue
+            }
+
             $ForwardingType = if ($HasExternalForwarding -and $HasInternalForwarding) {
                 'Both'
             } elseif ($HasExternalForwarding) {
                 'External'
-            } elseif ($HasInternalForwarding) {
-                'Internal'
             } else {
-                'None'
+                'Internal'
             }
 
             $ForwardTo = if ($HasExternalForwarding) {
                 $Mailbox.ForwardingSmtpAddress -replace 'smtp:', ''
-            } elseif ($HasInternalForwarding) {
-                $Mailbox.ForwardingAddress
             } else {
-                $null
+                $Mailbox.ForwardingAddress
             }
 
             [PSCustomObject]@{
@@ -81,7 +74,6 @@ function Invoke-ListMailboxForwarding {
                 ForwardingSmtpAddress      = $Mailbox.ForwardingSmtpAddress -replace 'smtp:', ''
                 InternalForwardingAddress  = $Mailbox.ForwardingAddress
                 DeliverToMailboxAndForward = $Mailbox.DeliverToMailboxAndForward
-                HasForwarding              = $HasAnyForwarding
             }
         }
 

--- a/Modules/CIPPCore/Public/Get-CIPPMailboxForwardingReport.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPMailboxForwardingReport.ps1
@@ -81,7 +81,9 @@ function Get-CIPPMailboxForwardingReport {
             }
 
             # Build the forward-to address display
-            $ForwardTo = if ($HasExternalForwarding) {
+            $ForwardTo = if ($HasExternalForwarding -and $HasInternalForwarding) {
+                "$($Mailbox.ForwardingSmtpAddress), $($Mailbox.InternalForwardingAddress)"
+            } elseif ($HasExternalForwarding) {
                 $Mailbox.ForwardingSmtpAddress
             } else {
                 $Mailbox.InternalForwardingAddress

--- a/Modules/CIPPCore/Public/Get-CIPPMailboxForwardingReport.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPMailboxForwardingReport.ps1
@@ -4,30 +4,20 @@ function Get-CIPPMailboxForwardingReport {
         Generates a mailbox forwarding report from the CIPP Reporting database
 
     .DESCRIPTION
-        Retrieves mailbox forwarding settings for a tenant from the cached mailbox data.
-        Shows mailboxes that have external forwarding, internal forwarding, or both configured.
+        Retrieves mailboxes that have forwarding configured (external, internal, or both)
+        from the cached mailbox data.
 
     .PARAMETER TenantFilter
         The tenant to generate the report for
 
-    .PARAMETER ForwardingOnly
-        If specified, only returns mailboxes that have forwarding configured
-
     .EXAMPLE
         Get-CIPPMailboxForwardingReport -TenantFilter 'contoso.onmicrosoft.com'
-        Gets all mailboxes with their forwarding settings
-
-    .EXAMPLE
-        Get-CIPPMailboxForwardingReport -TenantFilter 'contoso.onmicrosoft.com' -ForwardingOnly
-        Gets only mailboxes that have forwarding configured
+        Gets all mailboxes with forwarding configured
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$TenantFilter,
-
-        [Parameter(Mandatory = $false)]
-        [switch]$ForwardingOnly
+        [string]$TenantFilter
     )
 
     try {
@@ -45,9 +35,8 @@ function Get-CIPPMailboxForwardingReport {
             $AllResults = [System.Collections.Generic.List[PSCustomObject]]::new()
             foreach ($Tenant in $Tenants) {
                 try {
-                    $TenantResults = Get-CIPPMailboxForwardingReport -TenantFilter $Tenant -ForwardingOnly:$ForwardingOnly
+                    $TenantResults = Get-CIPPMailboxForwardingReport -TenantFilter $Tenant
                     foreach ($Result in $TenantResults) {
-                        # Add Tenant property to each result
                         $Result | Add-Member -NotePropertyName 'Tenant' -NotePropertyValue $Tenant -Force
                         $AllResults.Add($Result)
                     }
@@ -77,8 +66,8 @@ function Get-CIPPMailboxForwardingReport {
             $HasInternalForwarding = -not [string]::IsNullOrWhiteSpace($Mailbox.InternalForwardingAddress)
             $HasAnyForwarding = $HasExternalForwarding -or $HasInternalForwarding
 
-            # Skip mailboxes without forwarding if ForwardingOnly is specified
-            if ($ForwardingOnly -and -not $HasAnyForwarding) {
+            # Only include mailboxes with forwarding configured
+            if (-not $HasAnyForwarding) {
                 continue
             }
 
@@ -87,19 +76,15 @@ function Get-CIPPMailboxForwardingReport {
                 'Both'
             } elseif ($HasExternalForwarding) {
                 'External'
-            } elseif ($HasInternalForwarding) {
-                'Internal'
             } else {
-                'None'
+                'Internal'
             }
 
             # Build the forward-to address display
             $ForwardTo = if ($HasExternalForwarding) {
                 $Mailbox.ForwardingSmtpAddress
-            } elseif ($HasInternalForwarding) {
-                $Mailbox.InternalForwardingAddress
             } else {
-                $null
+                $Mailbox.InternalForwardingAddress
             }
 
             $Report.Add([PSCustomObject]@{
@@ -112,7 +97,6 @@ function Get-CIPPMailboxForwardingReport {
                     ForwardingSmtpAddress      = $Mailbox.ForwardingSmtpAddress
                     InternalForwardingAddress  = $Mailbox.InternalForwardingAddress
                     DeliverToMailboxAndForward = $Mailbox.DeliverToMailboxAndForward
-                    HasForwarding              = $HasAnyForwarding
                     Tenant                     = $TenantFilter
                     CacheTimestamp             = $CacheTimestamp
                 })

--- a/Modules/CIPPCore/Public/Get-CIPPMailboxForwardingReport.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPMailboxForwardingReport.ps1
@@ -80,10 +80,8 @@ function Get-CIPPMailboxForwardingReport {
                 'Internal'
             }
 
-            # Build the forward-to address display
-            $ForwardTo = if ($HasExternalForwarding -and $HasInternalForwarding) {
-                "$($Mailbox.ForwardingSmtpAddress), $($Mailbox.InternalForwardingAddress)"
-            } elseif ($HasExternalForwarding) {
+            # Build the forward-to address display (external takes precedence)
+            $ForwardTo = if ($HasExternalForwarding) {
                 $Mailbox.ForwardingSmtpAddress
             } else {
                 $Mailbox.InternalForwardingAddress


### PR DESCRIPTION
## Summary

- Remove ForwardingOnly parameter - report now always returns only mailboxes with forwarding
- ForwardTo field shows external address when both internal and external are configured (external takes precedence)

## Changes

- Simplified API by removing optional ForwardingOnly parameter
- External forwarding takes precedence in ForwardTo display when both are configured