### PR TITLE
Add ITGlue Conditional Access Policies sync

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionMapping.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionMapping.ps1
@@ -130,6 +130,23 @@ Function Invoke-ExecExtensionMapping {
     $StatusCode = [HttpStatusCode]::InternalServerError
   }
 
+  try {
+    if ($Request.Query.CreateCAType) {
+      switch ($Request.Query.CreateCAType) {
+        'ITGlue' {
+          $Result = New-ITGlueCAPolicyAssetType
+        }
+      }
+    }
+    $StatusCode = [HttpStatusCode]::OK
+  }
+  catch {
+    $ErrorMessage = Get-CippException -Exception $_
+    $Result = "Create CA Type API failed. $($ErrorMessage.NormalizedError)"
+    Write-LogMessage -API $APIName -headers $Headers -message $Result -Sev 'Error' -LogData $ErrorMessage
+    $StatusCode = [HttpStatusCode]::InternalServerError
+  }
+
   return ([HttpResponseContext]@{
       StatusCode = $StatusCode
       Body       = $Result

--- a/Modules/CippExtensions/Public/ITGlue/Get-ITGlueFieldMapping.ps1
+++ b/Modules/CippExtensions/Public/ITGlue/Get-ITGlueFieldMapping.ps1
@@ -29,6 +29,11 @@ function Get-ITGlueFieldMapping {
             FieldLabel = 'Flexible Asset Type for M365 Devices'
             FieldType  = 'FlexibleAssetTypes'
         }
+        [PSCustomObject]@{
+            FieldName  = 'ConditionalAccessPolicies'
+            FieldLabel = 'Flexible Asset Type for M365 Conditional Access Policies'
+            FieldType  = 'FlexibleAssetTypes'
+        }
     )
 
     $Table = Get-CIPPTable -TableName Extensionsconfig

--- a/Modules/CippExtensions/Public/ITGlue/Invoke-ITGlueExtensionSync.ps1
+++ b/Modules/CippExtensions/Public/ITGlue/Invoke-ITGlueExtensionSync.ps1
@@ -33,6 +33,7 @@ function Invoke-ITGlueExtensionSync {
         $OrgId = $TenantMap.IntegrationId
         $PeopleTypeId = ($Mappings | Where-Object { $_.PartitionKey -eq 'ITGlueFieldMapping' -and $_.RowKey -eq 'Users' }).IntegrationId
         $DeviceTypeId = ($Mappings | Where-Object { $_.PartitionKey -eq 'ITGlueFieldMapping' -and $_.RowKey -eq 'Devices' }).IntegrationId
+        $CATypeId = ($Mappings | Where-Object { $_.PartitionKey -eq 'ITGlueFieldMapping' -and $_.RowKey -eq 'ConditionalAccessPolicies' }).IntegrationId
 
         # Get M365 cached data
         $ExtensionCache = Get-CippExtensionReportingData -TenantFilter $Tenant.defaultDomainName -IncludeMailboxes
@@ -351,6 +352,327 @@ $(if ($Mailbox) { "<p><strong>Mailbox Size:</strong> $($Mailbox.TotalItemSize)</
                 $CompanyResult.Logs.Add("Native Configurations: Processed $($SyncDevices.Count) devices")
             } catch {
                 $CompanyResult.Errors.Add("Native Configurations block failed: $_")
+            }
+        }
+
+        # ─────────────────────────────────────────────────────────────────────
+        # CONDITIONAL ACCESS POLICIES — FLEXIBLE ASSETS
+        # ─────────────────────────────────────────────────────────────────────
+        if (![string]::IsNullOrEmpty($CATypeId)) {
+            try {
+                $CAPolicies = $ExtensionCache.ConditionalAccess
+                if ($CAPolicies -and $CAPolicies.Count -gt 0) {
+                    # Fetch reference data for ID resolution
+                    $Requests = @(
+                        @{ id = 'namedLocations'; url = 'identity/conditionalAccess/namedLocations'; method = 'GET' }
+                        @{ id = 'roleDefinitions'; url = 'roleManagement/directory/roleDefinitions?$select=id,displayName'; method = 'GET' }
+                        @{ id = 'servicePrincipals'; url = 'servicePrincipals?$top=999&$select=appId,displayName'; method = 'GET' }
+                        @{ id = 'applications'; url = 'applications?$top=999&$select=appId,displayName'; method = 'GET' }
+                    )
+                    $BulkResults = New-GraphBulkRequest -Requests $Requests -tenantid $Tenant.defaultDomainName -asapp $true
+
+                    $NamedLocations = ($BulkResults | Where-Object { $_.id -eq 'namedLocations' }).body.value
+                    $RoleDefinitions = ($BulkResults | Where-Object { $_.id -eq 'roleDefinitions' }).body.value
+                    $ServicePrincipals = ($BulkResults | Where-Object { $_.id -eq 'servicePrincipals' }).body.value
+                    $Applications = ($BulkResults | Where-Object { $_.id -eq 'applications' }).body.value
+
+                    # Helper functions for ID resolution
+                    function Get-ResolvedLocationName {
+                        param($Id)
+                        if ($Id -eq 'All') { return 'All' }
+                        if ($Id -eq 'AllTrusted') { return 'All trusted locations' }
+                        $Location = $NamedLocations | Where-Object { $_.id -eq $Id } | Select-Object -First 1
+                        if ($Location) { return $Location.displayName }
+                        return $Id
+                    }
+
+                    function Get-ResolvedRoleName {
+                        param($Id)
+                        if ($Id -eq 'All') { return 'All' }
+                        $Role = $RoleDefinitions | Where-Object { $_.id -eq $Id } | Select-Object -First 1
+                        if ($Role) { return $Role.displayName }
+                        return $Id
+                    }
+
+                    function Get-ResolvedAppName {
+                        param($Id)
+                        if ($Id -eq 'All') { return 'All' }
+                        if ($Id -eq 'None') { return 'None' }
+                        if ($Id -eq 'Office365') { return 'Office 365' }
+                        if ($Id -eq 'MicrosoftAdminPortals') { return 'Microsoft Admin Portals' }
+                        $App = $ServicePrincipals | Where-Object { $_.appId -eq $Id } | Select-Object -First 1
+                        if (!$App) { $App = $Applications | Where-Object { $_.appId -eq $Id } | Select-Object -First 1 }
+                        if (!$App) { $App = $Applications | Where-Object { $_.id -eq $Id } | Select-Object -First 1 }
+                        if ($App) { return $App.displayName }
+                        return $Id
+                    }
+
+                    function Get-ResolvedUserOrGroupName {
+                        param($Id)
+                        if ($Id -eq 'All') { return 'All users' }
+                        if ($Id -eq 'None') { return 'None' }
+                        if ($Id -eq 'GuestsOrExternalUsers') { return 'All guest and external users' }
+                        $User = $Users | Where-Object { $_.id -eq $Id } | Select-Object -First 1
+                        if ($User) { return "$($User.displayName) ($($User.userPrincipalName))" }
+                        $Group = $AllGroups | Where-Object { $_.id -eq $Id } | Select-Object -First 1
+                        if ($Group) { return $Group.displayName }
+                        return $Id
+                    }
+
+                    # Get existing CA Policy assets for this org
+                    $ExistingCAAssets = Invoke-ITGlueRequest -Method GET -Endpoint '/flexible_assets' -Headers $Conn.Headers -BaseUrl $Conn.BaseUrl -QueryParams @{
+                        'filter[flexible_asset_type_id]' = $CATypeId
+                        'filter[organization_id]'        = $OrgId
+                    }
+
+                    foreach ($Policy in $CAPolicies) {
+                        try {
+                            # Determine Users include type
+                            $UsersIncludeType = 'None'
+                            if ($Policy.conditions.users.includeUsers -contains 'All') {
+                                $UsersIncludeType = 'All users'
+                            } elseif ($Policy.conditions.users.includeUsers -contains 'GuestsOrExternalUsers' -or $Policy.conditions.users.includeGuestsOrExternalUsers) {
+                                $UsersIncludeType = 'All guest and external users'
+                            } elseif ($Policy.conditions.users.includeUsers -or $Policy.conditions.users.includeGroups -or $Policy.conditions.users.includeRoles) {
+                                $UsersIncludeType = 'Select users and groups'
+                            }
+
+                            # Determine Users exclude type
+                            $UsersExcludeType = 'None'
+                            if ($Policy.conditions.users.excludeUsers -contains 'GuestsOrExternalUsers' -or $Policy.conditions.users.excludeGuestsOrExternalUsers) {
+                                $UsersExcludeType = 'All guest and external users'
+                            } elseif ($Policy.conditions.users.excludeUsers -or $Policy.conditions.users.excludeGroups -or $Policy.conditions.users.excludeRoles) {
+                                $UsersExcludeType = 'Select users and groups'
+                            }
+
+                            # Resolve included users and groups
+                            $IncludedUsersAndGroups = @()
+                            if ($Policy.conditions.users.includeUsers) {
+                                $IncludedUsersAndGroups += $Policy.conditions.users.includeUsers | Where-Object { $_ -notin @('All', 'GuestsOrExternalUsers', 'None') } | ForEach-Object { Get-ResolvedUserOrGroupName -Id $_ }
+                            }
+                            if ($Policy.conditions.users.includeGroups) {
+                                $IncludedUsersAndGroups += $Policy.conditions.users.includeGroups | ForEach-Object { Get-ResolvedUserOrGroupName -Id $_ }
+                            }
+
+                            # Resolve excluded users and groups
+                            $ExcludedUsersAndGroups = @()
+                            if ($Policy.conditions.users.excludeUsers) {
+                                $ExcludedUsersAndGroups += $Policy.conditions.users.excludeUsers | Where-Object { $_ -notin @('All', 'GuestsOrExternalUsers', 'None') } | ForEach-Object { Get-ResolvedUserOrGroupName -Id $_ }
+                            }
+                            if ($Policy.conditions.users.excludeGroups) {
+                                $ExcludedUsersAndGroups += $Policy.conditions.users.excludeGroups | ForEach-Object { Get-ResolvedUserOrGroupName -Id $_ }
+                            }
+
+                            # Resolve directory roles
+                            $IncludedRoles = ($Policy.conditions.users.includeRoles | ForEach-Object { Get-ResolvedRoleName -Id $_ }) -join "`n"
+                            $ExcludedRoles = ($Policy.conditions.users.excludeRoles | ForEach-Object { Get-ResolvedRoleName -Id $_ }) -join "`n"
+
+                            # Determine Target resources include type
+                            $TargetResourcesInclude = 'None'
+                            if ($Policy.conditions.applications.includeApplications -contains 'All') {
+                                $TargetResourcesInclude = 'All cloud apps'
+                            } elseif ($Policy.conditions.applications.includeUserActions) {
+                                $TargetResourcesInclude = 'User actions'
+                            } elseif ($Policy.conditions.applications.includeAuthenticationContextClassReferences) {
+                                $TargetResourcesInclude = 'Authentication context'
+                            } elseif ($Policy.conditions.applications.includeApplications) {
+                                $TargetResourcesInclude = 'Select apps'
+                            }
+
+                            # Resolve applications
+                            $SelectApps = ($Policy.conditions.applications.includeApplications | Where-Object { $_ -notin @('All', 'None') } | ForEach-Object { Get-ResolvedAppName -Id $_ }) -join "`n"
+                            $ExcludedApps = ($Policy.conditions.applications.excludeApplications | ForEach-Object { Get-ResolvedAppName -Id $_ }) -join "`n"
+
+                            # Determine Network include type
+                            $NetworkInclude = 'Any network or location'
+                            if ($Policy.conditions.locations.includeLocations -contains 'All') {
+                                $NetworkInclude = 'Any network or location'
+                            } elseif ($Policy.conditions.locations.includeLocations -contains 'AllTrusted') {
+                                $NetworkInclude = 'All trusted networks and locations'
+                            } elseif ($Policy.conditions.locations.includeLocations) {
+                                $NetworkInclude = 'Selected networks and locations'
+                            }
+
+                            # Determine Network exclude type
+                            $NetworkExclude = 'None'
+                            if ($Policy.conditions.locations.excludeLocations -contains 'AllTrusted') {
+                                $NetworkExclude = 'All trusted networks and locations'
+                            } elseif ($Policy.conditions.locations.excludeLocations) {
+                                $NetworkExclude = 'Selected networks and locations'
+                            }
+
+                            # Resolve locations
+                            $IncludeLocations = ($Policy.conditions.locations.includeLocations | Where-Object { $_ -notin @('All', 'AllTrusted') } | ForEach-Object { Get-ResolvedLocationName -Id $_ }) -join "`n"
+                            $ExcludeLocations = ($Policy.conditions.locations.excludeLocations | Where-Object { $_ -notin @('All', 'AllTrusted') } | ForEach-Object { Get-ResolvedLocationName -Id $_ }) -join "`n"
+
+                            # Determine Grant or Block
+                            $GrantOrBlock = if ($Policy.grantControls.builtInControls -contains 'block') { 'Block access' } else { 'Grant access' }
+
+                            # Authentication strength
+                            $AuthStrength = $Policy.grantControls.authenticationStrength.displayName
+
+                            # Device filter
+                            $DeviceFilterMode = 'Not configured'
+                            if ($Policy.conditions.devices.deviceFilter.mode) {
+                                $DeviceFilterMode = switch ($Policy.conditions.devices.deviceFilter.mode) {
+                                    'include' { 'Include' }
+                                    'exclude' { 'Exclude' }
+                                    default { 'Not configured' }
+                                }
+                            }
+
+                            # Session controls
+                            $SignInFreqEnabled = [bool]$Policy.sessionControls.signInFrequency.isEnabled
+                            $SignInFreqValue = $Policy.sessionControls.signInFrequency.value
+                            $SignInFreqType = $Policy.sessionControls.signInFrequency.type
+                            if ($Policy.sessionControls.signInFrequency.frequencyInterval -eq 'everyTime') {
+                                $SignInFreqType = 'everyTime'
+                            }
+
+                            $PersistentBrowserEnabled = [bool]$Policy.sessionControls.persistentBrowser.isEnabled
+                            $PersistentBrowserMode = $Policy.sessionControls.persistentBrowser.mode
+
+                            $CAEMode = 'Not configured'
+                            if ($Policy.sessionControls.continuousAccessEvaluation.mode) {
+                                $CAEMode = switch ($Policy.sessionControls.continuousAccessEvaluation.mode) {
+                                    'disabled' { 'Disabled' }
+                                    'strictEnforcement' { 'Strictly enforced' }
+                                    default { 'Not configured' }
+                                }
+                            }
+
+                            # Build traits hashtable
+                            $Traits = @{
+                                'policy-name'                                     = $Policy.displayName
+                                'policy-description'                              = $Policy.description
+                                'policy-state'                                    = $Policy.state
+
+                                # Users
+                                'users-include'                                   = $UsersIncludeType
+                                'included-guest-or-external-roles'                = if ($Policy.conditions.users.includeGuestsOrExternalUsers) { ($Policy.conditions.users.includeGuestsOrExternalUsers | ConvertTo-Json -Depth 5) } else { '' }
+                                'included-directory-roles'                        = $IncludedRoles
+                                'included-users-and-groups'                       = ($IncludedUsersAndGroups -join "`n")
+                                'users-exclude'                                   = $UsersExcludeType
+                                'excluded-guest-or-external-roles'                = if ($Policy.conditions.users.excludeGuestsOrExternalUsers) { ($Policy.conditions.users.excludeGuestsOrExternalUsers | ConvertTo-Json -Depth 5) } else { '' }
+                                'excluded-directory-roles'                        = $ExcludedRoles
+                                'excluded-users-and-groups'                       = ($ExcludedUsersAndGroups -join "`n")
+
+                                # Target resources
+                                'target-resources-include'                        = $TargetResourcesInclude
+                                'select-apps'                                     = $SelectApps
+                                'user-actions'                                    = ($Policy.conditions.applications.includeUserActions -join "`n")
+                                'authentication-context'                          = ($Policy.conditions.applications.includeAuthenticationContextClassReferences -join "`n")
+                                'target-resources-excluded-cloud-apps'            = $ExcludedApps
+
+                                # Network
+                                'network-include'                                 = $NetworkInclude
+                                'network-include-selected-networks-and-locations' = $IncludeLocations
+                                'network-exclude'                                 = $NetworkExclude
+                                'network-exclude-selected-networks-and-locations' = $ExcludeLocations
+
+                                # User risk
+                                'user-risk-high'                                  = $Policy.conditions.userRiskLevels -contains 'high'
+                                'user-risk-medium'                                = $Policy.conditions.userRiskLevels -contains 'medium'
+                                'user-risk-low'                                   = $Policy.conditions.userRiskLevels -contains 'low'
+
+                                # Sign-in risk
+                                'sign-in-risk-high'                               = $Policy.conditions.signInRiskLevels -contains 'high'
+                                'sign-in-risk-medium'                             = $Policy.conditions.signInRiskLevels -contains 'medium'
+                                'sign-in-risk-low'                                = $Policy.conditions.signInRiskLevels -contains 'low'
+                                'sign-in-risk-no-risk'                            = $Policy.conditions.signInRiskLevels -contains 'none'
+
+                                # Insider risk
+                                'insider-risk-elevated'                           = $Policy.conditions.insiderRiskLevels -contains 'elevated'
+                                'insider-risk-moderate'                           = $Policy.conditions.insiderRiskLevels -contains 'moderate'
+                                'insider-risk-minor'                              = $Policy.conditions.insiderRiskLevels -contains 'minor'
+
+                                # Device platforms - Include
+                                'include-android'                                 = $Policy.conditions.platforms.includePlatforms -contains 'android'
+                                'include-ios'                                     = $Policy.conditions.platforms.includePlatforms -contains 'iOS'
+                                'include-windows'                                 = $Policy.conditions.platforms.includePlatforms -contains 'windows'
+                                'include-macos'                                   = $Policy.conditions.platforms.includePlatforms -contains 'macOS'
+                                'include-linux'                                   = $Policy.conditions.platforms.includePlatforms -contains 'linux'
+                                'include-windows-phone'                           = $Policy.conditions.platforms.includePlatforms -contains 'windowsPhone'
+
+                                # Device platforms - Exclude
+                                'exclude-android'                                 = $Policy.conditions.platforms.excludePlatforms -contains 'android'
+                                'exclude-ios'                                     = $Policy.conditions.platforms.excludePlatforms -contains 'iOS'
+                                'exclude-windows'                                 = $Policy.conditions.platforms.excludePlatforms -contains 'windows'
+                                'exclude-macos'                                   = $Policy.conditions.platforms.excludePlatforms -contains 'macOS'
+                                'exclude-linux'                                   = $Policy.conditions.platforms.excludePlatforms -contains 'linux'
+                                'exclude-windows-phone'                           = $Policy.conditions.platforms.excludePlatforms -contains 'windowsPhone'
+
+                                # Client apps
+                                'client-apps-configured'                          = [bool]$Policy.conditions.clientAppTypes
+                                'browser'                                         = $Policy.conditions.clientAppTypes -contains 'browser'
+                                'mobile-apps-and-desktop-clients'                 = $Policy.conditions.clientAppTypes -contains 'mobileAppsAndDesktopClients'
+                                'exchange-activesync-clients'                     = $Policy.conditions.clientAppTypes -contains 'exchangeActiveSync'
+                                'other-clients'                                   = $Policy.conditions.clientAppTypes -contains 'other'
+
+                                # Device filter
+                                'device-filter-mode'                              = $DeviceFilterMode
+                                'device-filter-rule'                              = $Policy.conditions.devices.deviceFilter.rule
+
+                                # Grant controls
+                                'grant-or-block'                                  = $GrantOrBlock
+                                'grant-controls-operator'                         = $Policy.grantControls.operator
+                                'require-multifactor-authentication'              = $Policy.grantControls.builtInControls -contains 'mfa'
+                                'require-authentication-strength'                 = $AuthStrength
+                                'require-device-to-be-marked-as-compliant'        = $Policy.grantControls.builtInControls -contains 'compliantDevice'
+                                'require-microsoft-entra-hybrid-joined-device'    = $Policy.grantControls.builtInControls -contains 'domainJoinedDevice'
+                                'require-approved-client-app'                     = $Policy.grantControls.builtInControls -contains 'approvedApplication'
+                                'require-app-protection-policy'                   = $Policy.grantControls.builtInControls -contains 'compliantApplication'
+                                'require-password-change'                         = $Policy.grantControls.builtInControls -contains 'passwordChange'
+                                'terms-of-use'                                    = ($Policy.grantControls.termsOfUse -join "`n")
+
+                                # Session controls
+                                'use-app-enforced-restrictions'                   = [bool]$Policy.sessionControls.applicationEnforcedRestrictions.isEnabled
+                                'use-conditional-access-app-control'              = [bool]$Policy.sessionControls.cloudAppSecurity.isEnabled
+                                'conditional-access-app-control-type'             = $Policy.sessionControls.cloudAppSecurity.cloudAppSecurityType
+                                'sign-in-frequency-enabled'                       = $SignInFreqEnabled
+                                'sign-in-frequency-value'                         = "$SignInFreqValue"
+                                'sign-in-frequency-type'                          = $SignInFreqType
+                                'persistent-browser-session-enabled'              = $PersistentBrowserEnabled
+                                'persistent-browser-session-mode'                 = $PersistentBrowserMode
+                                'continuous-access-evaluation'                    = $CAEMode
+                                'disable-resilience-defaults'                     = [bool]$Policy.sessionControls.disableResilienceDefaults
+                                'secure-sign-in-session'                          = [bool]$Policy.sessionControls.secureSignInSession.isEnabled
+
+                                # Metadata
+                                'policy-id'                                       = $Policy.id
+                                'created-date'                                    = if ($Policy.createdDateTime) { $Policy.createdDateTime } else { '' }
+                                'modified-date'                                   = if ($Policy.modifiedDateTime) { $Policy.modifiedDateTime } else { '' }
+                                'cipp-link'                                       = "$CIPPURL/tenant/conditional/list-policies?customerId=$($Tenant.customerId)"
+                                'entra-link'                                      = "https://entra.microsoft.com/$($Tenant.defaultDomainName)/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/$($Policy.id)"
+                                'last-synced'                                     = (Get-Date -Format 'yyyy-MM-dd HH:mm') + ' UTC'
+                            }
+
+                            # Find existing asset by policy ID
+                            $ExistingAsset = $ExistingCAAssets | Where-Object { $_.'policy-id' -eq $Policy.id } | Select-Object -First 1
+
+                            $AssetAttribs = @{
+                                'organization-id'        = $OrgId
+                                'flexible-asset-type-id' = $CATypeId
+                                traits                   = $Traits
+                            }
+
+                            if ($ExistingAsset) {
+                                $null = Invoke-ITGlueRequest -Method PATCH -Endpoint "/flexible_assets/$($ExistingAsset.id)" -Headers $Conn.Headers -BaseUrl $Conn.BaseUrl -ResourceType 'flexible-assets' -ResourceId $ExistingAsset.id -Attributes $AssetAttribs
+                            } else {
+                                $null = Invoke-ITGlueRequest -Method POST -Endpoint '/flexible_assets' -Headers $Conn.Headers -BaseUrl $Conn.BaseUrl -ResourceType 'flexible-assets' -Attributes $AssetAttribs
+                            }
+                            Start-Sleep -Milliseconds 100
+                        } catch {
+                            $CompanyResult.Errors.Add("CA Policy FA [$($Policy.displayName)]: $_")
+                        }
+                    }
+
+                    $CompanyResult.Logs.Add("CA Policy Flexible Assets: Processed $($CAPolicies.Count) policies")
+                } else {
+                    $CompanyResult.Logs.Add('CA Policy Flexible Assets: No policies found in cache')
+                }
+            } catch {
+                $CompanyResult.Errors.Add("CA Policy Flexible Assets block failed: $_")
             }
         }
 

--- a/Modules/CippExtensions/Public/ITGlue/New-ITGlueCAPolicyAssetType.ps1
+++ b/Modules/CippExtensions/Public/ITGlue/New-ITGlueCAPolicyAssetType.ps1
@@ -1,0 +1,194 @@
+function New-ITGlueCAPolicyAssetType {
+    <#
+    .FUNCTIONALITY
+        Internal
+    .SYNOPSIS
+        Creates the Conditional Access Policy Flexible Asset Type in ITGlue with all required fields.
+    .DESCRIPTION
+        Creates a new flexible asset type in ITGlue with 50+ fields to store detailed
+        conditional access policy information from Microsoft 365.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $Table = Get-CIPPTable -TableName Extensionsconfig
+    try {
+        $Configuration = (Get-CIPPAzDataTableEntity @Table).config | ConvertFrom-Json -ErrorAction Stop
+        $Conn = Connect-ITGlueAPI -Configuration $Configuration
+
+        # Define all the flexible asset fields for CA Policies
+        # Field positions are 1-based and sequential
+        $Fields = @(
+            # Policy name (required, use for title)
+            @{ name = 'Policy name'; kind = 'Text'; required = $true; 'use-for-title' = $true; 'show-in-list' = $true }
+            @{ name = 'Policy description'; kind = 'Text'; required = $false; 'show-in-list' = $false }
+            @{ name = 'Policy state'; kind = 'Select'; required = $false; 'show-in-list' = $true; 'default-value' = 'enabled,enabledForReportingButNotEnforced,disabled' }
+
+            # Users section
+            @{ name = 'Users'; kind = 'Header' }
+            @{ name = 'Users include'; kind = 'Select'; required = $false; 'default-value' = 'All users,None,Select users and groups,All guest and external users' }
+            @{ name = 'Included guest or external roles'; kind = 'Textbox'; required = $false }
+            @{ name = 'Included directory roles'; kind = 'Textbox'; required = $false }
+            @{ name = 'Included users and groups'; kind = 'Textbox'; required = $false }
+            @{ name = 'Users exclude'; kind = 'Select'; required = $false; 'default-value' = 'None,Select users and groups,All guest and external users' }
+            @{ name = 'Excluded guest or external roles'; kind = 'Textbox'; required = $false }
+            @{ name = 'Excluded directory roles'; kind = 'Textbox'; required = $false }
+            @{ name = 'Excluded users and groups'; kind = 'Textbox'; required = $false }
+
+            # Target resources section
+            @{ name = 'Target resources'; kind = 'Header' }
+            @{ name = 'Target resources include'; kind = 'Select'; required = $false; 'default-value' = 'All cloud apps,None,Select apps,User actions,Authentication context' }
+            @{ name = 'Select apps'; kind = 'Textbox'; required = $false }
+            @{ name = 'User actions'; kind = 'Textbox'; required = $false }
+            @{ name = 'Authentication context'; kind = 'Textbox'; required = $false }
+            @{ name = 'Target resources excluded cloud apps'; kind = 'Textbox'; required = $false }
+
+            # Network section
+            @{ name = 'Network'; kind = 'Header' }
+            @{ name = 'Network include'; kind = 'Select'; required = $false; 'default-value' = 'Any network or location,All trusted networks and locations,Selected networks and locations' }
+            @{ name = 'Network include - selected networks and locations'; kind = 'Textbox'; required = $false }
+            @{ name = 'Network exclude'; kind = 'Select'; required = $false; 'default-value' = 'None,All trusted networks and locations,Selected networks and locations' }
+            @{ name = 'Network exclude - selected networks and locations'; kind = 'Textbox'; required = $false }
+
+            # Conditions section
+            @{ name = 'Conditions'; kind = 'Header' }
+
+            # User risk
+            @{ name = 'User risk - high'; kind = 'Checkbox'; required = $false }
+            @{ name = 'User risk - medium'; kind = 'Checkbox'; required = $false }
+            @{ name = 'User risk - low'; kind = 'Checkbox'; required = $false }
+
+            # Sign-in risk
+            @{ name = 'Sign-in risk - high'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Sign-in risk - medium'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Sign-in risk - low'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Sign-in risk - no risk'; kind = 'Checkbox'; required = $false }
+
+            # Insider risk
+            @{ name = 'Insider risk - elevated'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Insider risk - moderate'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Insider risk - minor'; kind = 'Checkbox'; required = $false }
+
+            # Device platforms - Include
+            @{ name = 'Device platforms'; kind = 'Header' }
+            @{ name = 'Include Android'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Include iOS'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Include Windows'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Include macOS'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Include Linux'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Include Windows Phone'; kind = 'Checkbox'; required = $false }
+
+            # Device platforms - Exclude
+            @{ name = 'Exclude Android'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Exclude iOS'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Exclude Windows'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Exclude macOS'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Exclude Linux'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Exclude Windows Phone'; kind = 'Checkbox'; required = $false }
+
+            # Client apps
+            @{ name = 'Client apps'; kind = 'Header' }
+            @{ name = 'Client apps configured'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Browser'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Mobile apps and desktop clients'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Exchange ActiveSync clients'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Other clients'; kind = 'Checkbox'; required = $false }
+
+            # Device filters
+            @{ name = 'Filter for devices'; kind = 'Header' }
+            @{ name = 'Device filter mode'; kind = 'Select'; required = $false; 'default-value' = 'Not configured,Include,Exclude' }
+            @{ name = 'Device filter rule'; kind = 'Textbox'; required = $false }
+
+            # Grant controls
+            @{ name = 'Grant controls'; kind = 'Header' }
+            @{ name = 'Grant or Block'; kind = 'Select'; required = $false; 'default-value' = 'Grant access,Block access' }
+            @{ name = 'Grant controls operator'; kind = 'Select'; required = $false; 'default-value' = 'AND,OR' }
+            @{ name = 'Require multifactor authentication'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Require authentication strength'; kind = 'Text'; required = $false }
+            @{ name = 'Require device to be marked as compliant'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Require Microsoft Entra hybrid joined device'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Require approved client app'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Require app protection policy'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Require password change'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Terms of use'; kind = 'Textbox'; required = $false }
+
+            # Session controls
+            @{ name = 'Session controls'; kind = 'Header' }
+            @{ name = 'Use app enforced restrictions'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Use Conditional Access App Control'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Conditional Access App Control type'; kind = 'Text'; required = $false }
+            @{ name = 'Sign-in frequency enabled'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Sign-in frequency value'; kind = 'Text'; required = $false }
+            @{ name = 'Sign-in frequency type'; kind = 'Select'; required = $false; 'default-value' = 'hours,days,everyTime' }
+            @{ name = 'Persistent browser session enabled'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Persistent browser session mode'; kind = 'Select'; required = $false; 'default-value' = 'always,never' }
+            @{ name = 'Continuous access evaluation'; kind = 'Select'; required = $false; 'default-value' = 'Not configured,Disabled,Strictly enforced' }
+            @{ name = 'Disable resilience defaults'; kind = 'Checkbox'; required = $false }
+            @{ name = 'Secure sign-in session'; kind = 'Checkbox'; required = $false }
+
+            # Metadata
+            @{ name = 'Metadata'; kind = 'Header' }
+            @{ name = 'Policy ID'; kind = 'Text'; required = $false }
+            @{ name = 'Created date'; kind = 'Text'; required = $false }
+            @{ name = 'Modified date'; kind = 'Text'; required = $false }
+            @{ name = 'CIPP link'; kind = 'Text'; required = $false }
+            @{ name = 'Entra link'; kind = 'Text'; required = $false }
+            @{ name = 'Last synced'; kind = 'Text'; required = $false }
+        )
+
+        # Add position to each field
+        $Position = 1
+        $FieldsWithPosition = foreach ($Field in $Fields) {
+            $Field['position'] = $Position
+            $Position++
+            $Field
+        }
+
+        # Create the flexible asset type
+        $TypeBody = @{
+            data = @{
+                type       = 'flexible-asset-types'
+                attributes = @{
+                    name                      = 'M365 Conditional Access Policy'
+                    description               = 'Microsoft 365 Conditional Access Policies synced from CIPP'
+                    icon                      = 'shield-check'
+                    enabled                   = $true
+                    'flexible-asset-fields'   = @($FieldsWithPosition)
+                }
+            }
+        } | ConvertTo-Json -Depth 20 -Compress
+
+        $Response = Invoke-RestMethod -Uri "$($Conn.BaseUrl)/flexible_asset_types" -Method POST -Headers $Conn.Headers -Body $TypeBody
+
+        $CreatedTypeId = $Response.data.id
+        $CreatedTypeName = $Response.data.attributes.name
+
+        Write-LogMessage -Message "Created ITGlue Conditional Access Policy flexible asset type: $CreatedTypeName (ID: $CreatedTypeId)" -Level Info -tenant 'CIPP' -API 'ITGlueMapping'
+
+        return @{
+            Success = $true
+            Message = "Successfully created flexible asset type '$CreatedTypeName' (ID: $CreatedTypeId). You can now select it in the field mapping dropdown."
+            TypeId  = $CreatedTypeId
+            TypeName = $CreatedTypeName
+        }
+
+    } catch {
+        $ErrorMessage = if ($_.ErrorDetails.Message) {
+            try {
+                $ErrorBody = $_.ErrorDetails.Message | ConvertFrom-Json -ErrorAction SilentlyContinue
+                $ErrorBody.errors[0].detail ?? $ErrorBody.errors[0].title ?? $_.ErrorDetails.Message
+            } catch {
+                $_.ErrorDetails.Message
+            }
+        } else {
+            $_.Exception.Message
+        }
+
+        Write-LogMessage -Message "Failed to create ITGlue CA Policy flexible asset type: $ErrorMessage" -Level Error -tenant 'CIPP' -API 'ITGlueMapping'
+
+        return @{
+            Success = $false
+            Message = "Failed to create flexible asset type: $ErrorMessage"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add functionality to sync M365 Conditional Access policies to ITGlue as flexible assets with detailed individual fields
- **New-ITGlueCAPolicyAssetType.ps1**: Creates the CA Policy flexible asset type in ITGlue with 70+ fields covering all policy settings (users, target resources, network, conditions, device platforms, client apps, grant controls, session controls, metadata)
- **Get-ITGlueFieldMapping.ps1**: Add ConditionalAccessPolicies to available field mappings
- **Invoke-ExecExtensionMapping.ps1**: Add CreateCAType=ITGlue handler to allow creating the type via API
- **Invoke-ITGlueExtensionSync.ps1**: Add sync block that resolves IDs to display names and maps all policy fields to ITGlue traits

## Key Features
- Creates/updates flexible assets for each CA policy
- Resolves users, groups, roles, apps, and named locations from IDs to display names
- Matches existing assets by policy ID for updates
- Includes CIPP and Entra deep links in metadata

## Test plan
- [ ] Click "Create CA Policy Type" in UI to create the flexible asset type in ITGlue
- [ ] Verify type appears with all fields in ITGlue admin
- [ ] Select the type in the field mapping dropdown and save
- [ ] Run Force Sync and verify CA policies appear as flexible assets in ITGlue
- [ ] Verify all individual fields are populated correctly
- [ ] Modify a CA policy in Entra, re-sync, verify updates in ITGlue

🤖 Generated with [Claude Code](https://claude.com/claude-code)