### PR TITLE
Use script block in Sort-Object for hashtables

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAppManagementPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAppManagementPolicy.ps1
@@ -121,8 +121,9 @@ function Invoke-CIPPStandardAppManagementPolicy {
     }
 
     # Sort desired restrictions by restrictionType so order matches Graph API responses
-    $sortedDesiredPasswordCredentials = @($desiredPasswordCredentials | Sort-Object -Property restrictionType)
-    $sortedDesiredKeyCredentials = @($desiredKeyCredentials | Sort-Object -Property restrictionType)
+    # Use script block because items are hashtables, not PSCustomObjects
+    $sortedDesiredPasswordCredentials = @($desiredPasswordCredentials | Sort-Object { $_.restrictionType })
+    $sortedDesiredKeyCredentials = @($desiredKeyCredentials | Sort-Object { $_.restrictionType })
 
     $desiredState = [PSCustomObject]@{
         isEnabled                   = $true


### PR DESCRIPTION
Replace Sort-Object -Property with a script block ({ $_.restrictionType }) because the items are hashtables, not PSCustomObjects. This ensures desiredPasswordCredentials and desiredKeyCredentials are sorted correctly so their order matches Graph API responses.